### PR TITLE
feat: ignore skipped rom messages

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,37 @@ type ScrapeMedia struct {
 	IgnoreMissingRegion bool     `yaml:"ignore-missing-region"`
 }
 
+type scraperConfig struct {
+	Username string      `yaml:"username"`
+	Password string      `yaml:"password"`
+	Media    ScrapeMedia `yaml:"media"`
+	Threads  int         `yaml:"threads"`
+}
+
+type scraperSystem struct {
+	ID        string `yaml:"id"`
+	Name      string `yaml:"name"`
+	OutputDir string `yaml:"output-dir,omitempty"`
+	Dir       string `yaml:"dir"`
+}
+
+type boxartConfig struct {
+	Dir    string `yaml:"dir"`
+	Width  int    `yaml:"width"`
+	Height int    `yaml:"height"`
+}
+type userConfigs struct {
+	Boxart                  boxartConfig    `yaml:"thumbnail"`
+	Roms                    string          `yaml:"roms"`
+	Logos                   string          `yaml:"logos"`
+	Screenscraper           scraperConfig   `yaml:"screenscraper"`
+	Systems                 []scraperSystem `yaml:"systems"`
+	MaxScanDepth            int             `yaml:"max-scan-depth"`
+	ExcludeExtensions       []string        `yaml:"exclude-extensions"`
+	IgnoreSkippedRomMessage bool            `yaml:"ignore-skipped-rom-message,omitempty"`
+	Debug                   bool            `yaml:"debug,omitempty"`
+}
+
 var (
 	ConfigFile         = "screech.yaml"
 	Debug              bool
@@ -76,6 +107,7 @@ var (
 		".state",
 		".srm",
 	}
+	IgnoreSkippedRomMessage bool
 )
 
 func InitVars() {
@@ -94,6 +126,7 @@ func InitVars() {
 	} else {
 		ExcludeExtensions = cfg.ExcludeExtensions
 	}
+	IgnoreSkippedRomMessage = cfg.IgnoreSkippedRomMessage
 	Username = cfg.Screenscraper.Username
 	Password = cfg.Screenscraper.Password
 	Threads = cfg.Screenscraper.Threads
@@ -142,36 +175,6 @@ func ScrapedImgDir(outputDir string) string {
 	dir = strings.ReplaceAll(dir, "\\", string(filepath.Separator))
 	dir = strings.ReplaceAll(dir, "%SYSTEM%", outputDir)
 	return dir
-}
-
-type scraperConfig struct {
-	Username string      `yaml:"username"`
-	Password string      `yaml:"password"`
-	Media    ScrapeMedia `yaml:"media"`
-	Threads  int         `yaml:"threads"`
-}
-
-type scraperSystem struct {
-	ID        string `yaml:"id"`
-	Name      string `yaml:"name"`
-	OutputDir string `yaml:"output-dir,omitempty"`
-	Dir       string `yaml:"dir"`
-}
-
-type boxartConfig struct {
-	Dir    string `yaml:"dir"`
-	Width  int    `yaml:"width"`
-	Height int    `yaml:"height"`
-}
-type userConfigs struct {
-	Boxart            boxartConfig    `yaml:"thumbnail"`
-	Roms              string          `yaml:"roms"`
-	Logos             string          `yaml:"logos"`
-	Screenscraper     scraperConfig   `yaml:"screenscraper"`
-	Systems           []scraperSystem `yaml:"systems"`
-	MaxScanDepth      int             `yaml:"max-scan-depth"`
-	ExcludeExtensions []string        `yaml:"exclude-extensions"`
-	Debug             bool            `yaml:"debug,omitempty"`
 }
 
 func readConfigFile() (*userConfigs, error) {

--- a/includes/screech.yaml
+++ b/includes/screech.yaml
@@ -1,6 +1,7 @@
 roms: /mnt/SDCARD/Roms/ # Path to the roms folder
 logos: /mnt/SDCARD/Icons/Default/Logos # Path to the console logos folder, should contain PNG files
 max-scan-depth: 2 # Maximum number of subdirectories to scan for roms
+ignore-skipped-rom-message: true # Do not display a message when a rom is skipped
 exclude-extensions: # List of file extensions to exclude from the scan
   - ".cue"
   - ".m3u"

--- a/screens/scraping_test.go
+++ b/screens/scraping_test.go
@@ -170,8 +170,8 @@ func TestWorker(t *testing.T) {
 			hasScrapedImageFunc: func(rom string) bool {
 				return false
 			},
-			expectedEvents: []string{"Skipping game1.txt: invalid file"},
-			expectedCounts: counter{success: newUint32(0), failed: newUint32(0), skipped: newUint32(1)},
+			expectedEvents: []string{},
+			expectedCounts: counter{success: newUint32(0), failed: newUint32(0), skipped: newUint32(0)},
 		},
 		{
 			name: "Already scraped ROM",
@@ -317,8 +317,8 @@ func TestBuildWorkerPool(t *testing.T) {
 			hasScrapedImageFunc: func(rom string) bool {
 				return false
 			},
-			expectedEvents: []string{"Scrapped game1", "Skipping game2.txt: invalid file", "Scraping finished.", "Success: 1", "Failed: 0", "Skipped: 1"},
-			expectedCounts: counter{success: newUint32(1), failed: newUint32(0), skipped: newUint32(1)},
+			expectedEvents: []string{"Scrapped game1", "Scraping finished.", "Success: 1", "Failed: 0", "Skipped: 0"},
+			expectedCounts: counter{success: newUint32(1), failed: newUint32(0), skipped: newUint32(0)},
 		},
 		{
 			name: "Already scraped ROMs",


### PR DESCRIPTION
closes #9 

# What?

Add new configuration attribute `ignore-skipped-rom-message` with default value `true`