### PR TITLE
feat: display error on screen

### DIFF
--- a/components/list.go
+++ b/components/list.go
@@ -47,6 +47,9 @@ func (l *List[T]) ScrollDown() {
 		if l.selectedIndex >= l.scrollOffset+l.maxVisibleItems {
 			l.scrollOffset++
 		}
+	} else {
+		l.selectedIndex = 0
+		l.scrollOffset = 0
 	}
 }
 
@@ -56,6 +59,9 @@ func (l *List[T]) ScrollUp() {
 		if l.selectedIndex < l.scrollOffset {
 			l.scrollOffset--
 		}
+	} else {
+		l.selectedIndex = len(l.items) - 1
+		l.scrollOffset = 0
 	}
 }
 
@@ -101,6 +107,11 @@ func (l *List[T]) GetScrollOffset() int {
 }
 
 func (l *List[T]) SelectedValue() T {
+	if len(l.items) == 0 {
+		var zeroValue T
+		return zeroValue
+	}
+
 	return l.items[l.selectedIndex].Value
 }
 


### PR DESCRIPTION
# Context

This pull request includes several significant changes to the `components/list.go` and `screens/home.go` files. The changes primarily focus on improving the list scrolling functionality, handling empty list selections, and enhancing error handling and display in the home screen.

# What?
### List Scrolling Improvements:
* [`components/list.go`](diffhunk://#diff-850dfb24bc0072eaf2e7ebaac3605dd80ac310d3bce05b57cc50eed54af00aabR50-R52): Modified `ScrollDown` and `ScrollUp` methods to reset the selected index and scroll offset when reaching the bounds of the list. [[1]](diffhunk://#diff-850dfb24bc0072eaf2e7ebaac3605dd80ac310d3bce05b57cc50eed54af00aabR50-R52) [[2]](diffhunk://#diff-850dfb24bc0072eaf2e7ebaac3605dd80ac310d3bce05b57cc50eed54af00aabR62-R64)
* [`components/list.go`](diffhunk://#diff-850dfb24bc0072eaf2e7ebaac3605dd80ac310d3bce05b57cc50eed54af00aabR110-R114): Updated `SelectedValue` method to handle cases where the list is empty by returning a zero value.

### Home Screen Enhancements:
* [`screens/home.go`](diffhunk://#diff-27acbaff362aa484890bd6d494b8fa77f3423d0bc53395dc8c292f61ad5c8132L19-R20): Renamed `listComponent` to `systemsList` and added a new `textView` component for displaying error messages. [[1]](diffhunk://#diff-27acbaff362aa484890bd6d494b8fa77f3423d0bc53395dc8c292f61ad5c8132L19-R20) [[2]](diffhunk://#diff-27acbaff362aa484890bd6d494b8fa77f3423d0bc53395dc8c292f61ad5c8132L34-R85)
* [`screens/home.go`](diffhunk://#diff-27acbaff362aa484890bd6d494b8fa77f3423d0bc53395dc8c292f61ad5c8132L34-R85): Enhanced `InitHome` method to display errors in `textView` instead of panicking, and updated the `HandleInput` method to prevent actions when in error mode. [[1]](diffhunk://#diff-27acbaff362aa484890bd6d494b8fa77f3423d0bc53395dc8c292f61ad5c8132L34-R85) [[2]](diffhunk://#diff-27acbaff362aa484890bd6d494b8fa77f3423d0bc53395dc8c292f61ad5c8132L81-R104)
* [`screens/home.go`](diffhunk://#diff-27acbaff362aa484890bd6d494b8fa77f3423d0bc53395dc8c292f61ad5c8132L81-R104): Modified `updateLogo` method to check for the existence of the logo file before rendering.
* [`screens/home.go`](diffhunk://#diff-27acbaff362aa484890bd6d494b8fa77f3423d0bc53395dc8c292f61ad5c8132L96-R126): Updated `Draw` method to conditionally draw the `textView` if there are error messages.

### Error Handling Improvements:
* [`screens/home.go`](diffhunk://#diff-27acbaff362aa484890bd6d494b8fa77f3423d0bc53395dc8c292f61ad5c8132L142-R181): Refactored `listRomsDirs` to return an error instead of panicking, improving robustness and error handling. [[1]](diffhunk://#diff-27acbaff362aa484890bd6d494b8fa77f3423d0bc53395dc8c292f61ad5c8132L142-R181) [[2]](diffhunk://#diff-27acbaff362aa484890bd6d494b8fa77f3423d0bc53395dc8c292f61ad5c8132L166-R192)

