### PR TITLE
feat: improve ScreenScraper api error handling

### DIFF
--- a/scraper/client.go
+++ b/scraper/client.go
@@ -22,20 +22,20 @@ import (
 type MediaType string
 
 var (
-	DevID                           = "1234"
-	DevPassword                     = "password"
-	BaseURL                         = "https://www.screenscraper.fr/api2/jeuInfos.php"
-	UnreadableBodyErr               = errors.New("unreadable body")
-	EmptyBodyErr                    = errors.New("empty body")
-	GameNotFoundErr                 = errors.New("game not found")
-	APIClosedErr                    = errors.New("API closed")
-	HTTPRequestErr                  = errors.New("error making HTTP request")
-	HTTPRequestAbortedErr           = errors.New("request aborted")
-	UnknownMediaTypeErr             = errors.New("unknown media type, choose among box-2D, box-3D, mixrbv1, mixrbv2")
-	Box2D                 MediaType = "box-2D"
-	Box3D                 MediaType = "box-3D"
-	MixV1                 MediaType = "mixrbv1"
-	MixV2                 MediaType = "mixrbv2"
+	DevID       = "1234"
+	DevPassword = "password"
+	BaseURL     = "https://www.screenscraper.fr/api2/jeuInfos.php"
+
+	EmptyBodyErr = errors.New("empty body")
+	// APIClosedErr          = errors.New("API closed")
+	HTTPRequestErr        = errors.New("error making HTTP request")
+	HTTPRequestAbortedErr = errors.New("request aborted")
+	UnknownMediaTypeErr   = errors.New("unknown media type, choose among box-2D, box-3D, mixrbv1, mixrbv2")
+
+	Box2D MediaType = "box-2D"
+	Box3D MediaType = "box-3D"
+	MixV1 MediaType = "mixrbv1"
+	MixV2 MediaType = "mixrbv2"
 )
 
 const maxFileSizeBytes = 104857600 // 100MB
@@ -187,22 +187,7 @@ func get(ctx context.Context, url string) ([]byte, error) {
 	}
 	defer res.Body.Close()
 
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, errors.Join(UnreadableBodyErr, fmt.Errorf("error: %w", err))
-	}
-
-	s := string(body)
-	switch {
-	case strings.Contains(s, "API closed"):
-		return nil, APIClosedErr
-	case strings.Contains(s, "Erreur"):
-		return nil, errors.Join(GameNotFoundErr, fmt.Errorf(": %s", s))
-	case s == "":
-		return nil, EmptyBodyErr
-	}
-
-	return body, nil
+	return handleResponse(res)
 }
 
 func saveToDisk(dest string, file []byte) error {

--- a/scraper/errors.go
+++ b/scraper/errors.go
@@ -1,0 +1,104 @@
+package scraper
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+var (
+	ServerLockedErr        = errors.New("server is locked")
+	ServerOverloadedErr    = errors.New("The server is overloaded")
+	TooManyRequestsErr     = errors.New("too many requests")
+	ToowManyUnknownRomsErr = errors.New("Member has scraped too many unrecognized roms (see F.A.Q)")
+	AppHasBeenBlockedErr   = errors.New("the app has been blocked")
+	GameNotFoundErr        = errors.New("game not found")
+	ScrapeQuotaErr         = errors.New("scrape quota has been exceeded for today")
+	UnreadableBodyErr      = errors.New("unreadable body")
+	RomFileNameErr         = errors.New("rom file name is not correct")
+	DevLoginErr            = errors.New("Screech cannot access the server")
+	BadRequestErr          = errors.New("bad request")
+)
+
+func handleResponse(res *http.Response) ([]byte, error) {
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, errors.Join(UnreadableBodyErr, err)
+	}
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		return body, nil
+	case http.StatusBadRequest:
+		return nil, handleBadRequest(string(body))
+	case http.StatusUnauthorized:
+		return nil, ServerOverloadedErr
+	case http.StatusForbidden:
+		return nil, DevLoginErr
+	case http.StatusNotFound:
+		return nil, GameNotFoundErr
+	case http.StatusLocked:
+		return nil, ServerLockedErr
+	case http.StatusUpgradeRequired:
+		return nil, AppHasBeenBlockedErr
+	case http.StatusTooManyRequests:
+		return nil, TooManyRequestsErr
+	case http.StatusRequestHeaderFieldsTooLarge:
+		return nil, ToowManyUnknownRomsErr
+	case 430:
+		return nil, ScrapeQuotaErr
+
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d, response: %s", res.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+func handleBadRequest(message string) error {
+	if strings.Contains(message, "nom du fichier rom") {
+		return RomFileNameErr
+	}
+
+	if isFieldError(message) {
+		field, err := extractMiddleText(message)
+		if err != nil {
+			return errors.New("unknow field error")
+		}
+		return fmt.Errorf("field error: %s", field)
+	}
+
+	return errors.Join(BadRequestErr, errors.New(message))
+}
+
+func normalizeString(s string) string {
+	var normalized []rune
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsSpace(r) {
+			normalized = append(normalized, unicode.ToLower(r))
+		}
+	}
+	return string(normalized)
+}
+
+func extractMiddleText(s string) (string, error) {
+	normalized := normalizeString(s)
+	re := regexp.MustCompile(`(?i)champ\s+(.*?)\s+errone`)
+	matches := re.FindStringSubmatch(normalized)
+	if len(matches) > 1 {
+		return strings.TrimSpace(matches[1]), nil
+	}
+	return "", errors.New("string does not contain the required text")
+}
+
+func isFieldError(s string) bool {
+	normalized := normalizeString(s)
+	re := regexp.MustCompile(`(?i)champ\s+.*?\s+errone`)
+	return re.MatchString(normalized)
+}

--- a/scraper/errors_test.go
+++ b/scraper/errors_test.go
@@ -1,0 +1,120 @@
+package scraper
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestHandleResponse(t *testing.T) {
+	tests := []struct {
+		name           string
+		statusCode     int
+		body           string
+		expectedError  error
+		expectedResult string
+	}{
+		{
+			name:           "StatusOK",
+			statusCode:     http.StatusOK,
+			body:           "OK",
+			expectedError:  nil,
+			expectedResult: "OK",
+		},
+		{
+			name:           "StatusBadRequest",
+			statusCode:     http.StatusBadRequest,
+			body:           "nom du fichier rom",
+			expectedError:  RomFileNameErr,
+			expectedResult: "",
+		},
+		{
+			name:           "StatusUnauthorized",
+			statusCode:     http.StatusUnauthorized,
+			body:           "Unauthorized",
+			expectedError:  ServerOverloadedErr,
+			expectedResult: "",
+		},
+		{
+			name:           "StatusForbidden",
+			statusCode:     http.StatusForbidden,
+			body:           "Forbidden",
+			expectedError:  DevLoginErr,
+			expectedResult: "",
+		},
+		{
+			name:           "StatusNotFound",
+			statusCode:     http.StatusNotFound,
+			body:           "Not Found",
+			expectedError:  GameNotFoundErr,
+			expectedResult: "",
+		},
+		{
+			name:           "StatusLocked",
+			statusCode:     http.StatusLocked,
+			body:           "Locked",
+			expectedError:  ServerLockedErr,
+			expectedResult: "",
+		},
+		{
+			name:           "StatusUpgradeRequired",
+			statusCode:     http.StatusUpgradeRequired,
+			body:           "Upgrade Required",
+			expectedError:  AppHasBeenBlockedErr,
+			expectedResult: "",
+		},
+		{
+			name:           "StatusTooManyRequests",
+			statusCode:     http.StatusTooManyRequests,
+			body:           "Too Many Requests",
+			expectedError:  TooManyRequestsErr,
+			expectedResult: "",
+		},
+		{
+			name:           "StatusRequestHeaderFieldsTooLarge",
+			statusCode:     http.StatusRequestHeaderFieldsTooLarge,
+			body:           "Request Header Fields Too Large",
+			expectedError:  ToowManyUnknownRomsErr,
+			expectedResult: "",
+		},
+		{
+			name:           "StatusScrapeQuotaExceeded",
+			statusCode:     430,
+			body:           "Scrape Quota Exceeded",
+			expectedError:  ScrapeQuotaErr,
+			expectedResult: "",
+		},
+		{
+			name:           "UnexpectedStatusCode",
+			statusCode:     http.StatusInternalServerError,
+			body:           "Internal Server Error",
+			expectedError:  errors.New("unexpected status code: 500, response: Internal Server Error"),
+			expectedResult: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := &http.Response{
+				StatusCode: tt.statusCode,
+				Body:       io.NopCloser(strings.NewReader(tt.body)),
+			}
+
+			result, err := handleResponse(res)
+			if tt.expectedError != nil && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if tt.expectedError == nil && err != nil {
+				t.Errorf("did not expect error but got: %v", err)
+			}
+			if tt.expectedError != nil && err != nil && err.Error() != tt.expectedError.Error() {
+				t.Errorf("expected error: %v, got: %v", tt.expectedError, err)
+			}
+			if string(result) != tt.expectedResult {
+				t.Errorf("expected result: %s, got: %s", tt.expectedResult, string(result))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request includes several changes to the `scraper` package to improve error handling and testing. The key changes involve refactoring error handling into a new `handleResponse` function, updating the tests to reflect these changes, and cleaning up the code.

### Error Handling Improvements:
* Added a new `handleResponse` function in `scraper/errors.go` to centralize HTTP response handling and error generation. This function now handles various HTTP status codes and maps them to specific errors.

### Code Cleanup:
* Removed the old error handling logic from the `get` function in `scraper/client.go` and replaced it with a call to the new `handleResponse` function.
* Cleaned up unused error variables and commented out the `APIClosedErr` in `scraper/client.go`.

### Testing Enhancements:
* Added comprehensive tests for the `handleResponse` function in a new test file `scraper/errors_test.go`. These tests cover various HTTP status codes and their corresponding error handling.
* Updated the `setupStubServer` function in `scraper/scraper_test.go` to remove the `resp` parameter, simplifying the setup of the test server. [[1]](diffhunk://#diff-b86907ed4a660617821dca4402de855fcff7cc00e7cdc19cb9b8a670ae6ae1cfL17-R17) [[2]](diffhunk://#diff-b86907ed4a660617821dca4402de855fcff7cc00e7cdc19cb9b8a670ae6ae1cfL47-R54)
* Removed outdated tests that checked for specific error responses directly in the `TestFindGameResponseErrors` function, as this logic is now handled by the `handleResponse` function.

These changes collectively enhance the robustness and maintainability of the error handling logic within the `scraper` package.

close #4 