### PR TITLE
bug: fix Atomiswave name in config

### DIFF
--- a/includes/screech.yaml
+++ b/includes/screech.yaml
@@ -60,7 +60,7 @@ systems:
     name: Atari ST
   - dir: ATOMISWAVE
     id: "53"
-    name: Atari ST
+    name: Atomiswave
   - dir: COLECO
     id: "183"
     name: Coleco


### PR DESCRIPTION
This pull request includes a correction to the `includes/screech.yaml` file to fix a naming error for the Atomiswave system.

* [`includes/screech.yaml`](diffhunk://#diff-a0859304d9e2dab23672554c352442bbd659a3a3eb7ab08a7aac03a40576716aL63-R63): Corrected the name of the system from "Atari ST" to "Atomiswave".

close #17 