### PR TITLE
fix: show bottom of list when scrolling up

### DIFF
--- a/components/list.go
+++ b/components/list.go
@@ -62,17 +62,14 @@ func (l *List[T]) ScrollUp() {
 		}
 	} else {
 		l.selectedIndex = len(l.items) - 1
-		l.scrollOffset = 0
+		l.scrollOffset = max(len(l.items)-l.maxVisibleItems, 0)
 	}
 }
 
 func (l *List[T]) Draw(primaryColor sdl.Color, selectedColor sdl.Color) {
 	// Draw the items
 	startIndex := l.scrollOffset
-	endIndex := startIndex + l.maxVisibleItems
-	if endIndex > len(l.items) {
-		endIndex = len(l.items)
-	}
+	endIndex := min(startIndex+l.maxVisibleItems, len(l.items))
 	visibleItems := l.items[startIndex:endIndex]
 
 	for index, item := range visibleItems {


### PR DESCRIPTION
This pull request includes changes to improve the scrolling behavior in the `List` component. The changes ensure that the scroll offset is correctly calculated to prevent out-of-bounds errors and improve the drawing of visible items.

Key changes:

* [`components/list.go`](diffhunk://#diff-850dfb24bc0072eaf2e7ebaac3605dd80ac310d3bce05b57cc50eed54af00aabL65-R72): Modified the `ScrollUp` method to correctly set the `scrollOffset` to the maximum of the difference between the number of items and the maximum visible items, ensuring it does not go below zero.
* [`components/list.go`](diffhunk://#diff-850dfb24bc0072eaf2e7ebaac3605dd80ac310d3bce05b57cc50eed54af00aabL65-R72): Updated the `Draw` method to use the `min` function for calculating the `endIndex`, ensuring it does not exceed the number of items.