### PR TITLE
fix: system names and codes

### DIFF
--- a/includes/screech.yaml
+++ b/includes/screech.yaml
@@ -48,7 +48,7 @@ systems:
     name: Commodore Amiga CD
   - dir: ARCADE
     id: "75"
-    name: Mame
+    name: Arcade
   - dir: ARDUBOY
     id: "263"
     name: Arduboy
@@ -114,10 +114,10 @@ systems:
     name: FBA2012
   - dir: FBALPHA
     id: "75"
-    name: FBAlpha
+    name: Final Burn Alpha
   - dir: FBNEO
     id: "75"
-    name: FBNeo
+    name: Final Burn Neo
   - dir: FC
     id: "3"
     name: NES (Famicom)
@@ -282,10 +282,10 @@ systems:
     name: Sufami Turbo
   - dir: WS
     id: "207"
-    name: Watara Supervision
+    name: WonderSwan
   - dir: WSC
-    id: "207"
-    name: Watara Supervision
+    id: "45"
+    name: WonderSwan Color
   - dir: SEGA32X
     id: "19"
     name: Sega 32X


### PR DESCRIPTION
closes #21 

This pull request includes changes to the `includes/screech.yaml` file, focusing on updating the naming conventions for various systems to improve consistency and clarity.

Changes in naming conventions:

* Changed the system name from "Mame" to "Arcade" (`includes/screech.yaml`)
* Updated the system name from "FBAlpha" to "Final Burn Alpha" (`includes/screech.yaml`)
* Updated the system name from "FBNeo" to "Final Burn Neo" (`includes/screech.yaml`)
* Changed the system name from "Watara Supervision" to "WonderSwan" (`includes/screech.yaml`)
* Updated the system name from "Watara Supervision" to "WonderSwan Color" and corrected the `id` (`includes/screech.yaml`)