### PR TITLE
feat: add ignored rom dirs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,7 @@ type userConfigs struct {
 	MaxScanDepth            int             `yaml:"max-scan-depth"`
 	ExcludeExtensions       []string        `yaml:"exclude-extensions"`
 	IgnoreSkippedRomMessage bool            `yaml:"ignore-skipped-rom-message,omitempty"`
+	IgnoreDirs              []string        `yaml:"ignore-dirs"`
 	Debug                   bool            `yaml:"debug,omitempty"`
 }
 
@@ -109,6 +110,7 @@ var (
 		".srm",
 	}
 	IgnoreSkippedRomMessage bool
+	IgnoreDirs              []string
 )
 
 func InitVars() {
@@ -128,6 +130,7 @@ func InitVars() {
 		ExcludeExtensions = cfg.ExcludeExtensions
 	}
 	IgnoreSkippedRomMessage = cfg.IgnoreSkippedRomMessage
+	IgnoreDirs = cfg.IgnoreDirs
 	Username = cfg.Screenscraper.Username
 	Password = cfg.Screenscraper.Password
 	Threads = cfg.Screenscraper.Threads

--- a/includes/screech.yaml
+++ b/includes/screech.yaml
@@ -2,6 +2,22 @@ roms: /mnt/SDCARD/Roms/ # Path to the roms folder
 logos: /mnt/SDCARD/Icons/Default/Logos # Path to the console logos folder, should contain PNG files
 max-scan-depth: 2 # Maximum number of subdirectories to scan for roms
 ignore-skipped-rom-message: true # Do not display a message when a rom is skipped
+ignore-dirs: # Directories to ignore when scanning for roms
+  - MUSIC 
+  - VIDEOS 
+  - CANNONBALL 
+  - CAVESTORY 
+  - CHAILOVE 
+  - DINOTHAWR 
+  - DOOM 
+  - ENTERPRISE 
+  - FLASHBACK 
+  - PGM 
+  - TI83 
+  - TYRQUAKE 
+  - VIDEOTON 
+  - VMAC 
+  - XRICK
 exclude-extensions: # List of file extensions to exclude from the scan
   - ".cue"
   - ".m3u"
@@ -316,9 +332,6 @@ systems:
   - dir: VMU
     id: "23"
     name: Dreamcast VMU
-  - dir: WS
-    id: "45"
-    name: Bandai WonderSwan
   - dir: X68000
     id: "79"
     name: Sharp X68000

--- a/screens/scraping.go
+++ b/screens/scraping.go
@@ -209,7 +209,7 @@ func findRoms(ctx context.Context, events chan<- string, romDirs []romDirSetting
 							if depth > maxDepth-1 || strings.HasPrefix(filepath.Base(path), ".") {
 								return filepath.SkipDir
 							}
-							events <- "Walking " + romDir.Path
+							events <- "Walking " + strings.TrimPrefix(path, config.RomsBaseDir)
 						} else {
 							roms <- Rom{
 								Name:      filepath.Base(path),
@@ -237,7 +237,7 @@ func buildWorkerPool(ctx context.Context, cancel context.CancelFunc, workers int
 	)
 
 	wg.Add(workers)
-	for i := 0; i < workers; i++ {
+	for range workers {
 		go worker(ctx, &wg, roms, events, &counter{&success, &failed, &skipped})
 	}
 


### PR DESCRIPTION
This pull request includes several changes to the configuration and scanning logic for the ROM management system. The most notable updates involve the addition of a feature to ignore specific directories during the scan, the usage of the `slices` package for sorting, and some refactoring for better readability and maintainability.

### Configuration updates:
* Added `IgnoreDirs` field to the `userConfigs` struct and the corresponding initialization in `config/config.go`. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R63) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R113) [[3]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R133)
* Updated `includes/screech.yaml` to include a list of directories to ignore during the scan.

### Codebase improvements:
* Replaced manual sorting logic with the `slices.SortFunc` utility for better performance and readability in `screens/home.go`.
* Refactored the directory filtering logic into separate functions `filterDirs`, `hasVisibleEntries`, and `isAllowedDir` to improve code clarity in `screens/home.go`. [[1]](diffhunk://#diff-27acbaff362aa484890bd6d494b8fa77f3423d0bc53395dc8c292f61ad5c8132L176-R187) [[2]](diffhunk://#diff-27acbaff362aa484890bd6d494b8fa77f3423d0bc53395dc8c292f61ad5c8132R198-R220)

### Minor changes:
* Modified the event message to trim the base directory path in `screens/scraping.go`.
* Simplified the worker pool creation loop in `screens/scraping.go`.